### PR TITLE
made exit codes portable for Windows platforms

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -129,4 +129,4 @@ def log(msg):
 
 if __name__ == "__main__":
     r = run()
-    sys.exit(os.EX_OK if r == 0 else os.EX_SOFTWARE)
+    sys.exit(0 if r == 0 else 1)


### PR DESCRIPTION
According to https://docs.python.org/3.5/library/os.html os.EX_OK and os.EX_SOFTWARE are available  on Unix only