### PR TITLE
Fix 'infinit' looping on receiving messages when their amount is very high

### DIFF
--- a/plenum/common/zstack.py
+++ b/plenum/common/zstack.py
@@ -543,8 +543,16 @@ class ZStack(NetworkInterface):
 
     async def _serviceStack(self, age):
         # TODO: age is unused
-        self._receiveFromListener(quota=5)
-        self._receiveFromRemotes(quotaPerRemote=5)
+
+        from plenum.common.config_util import getConfig
+        config = getConfig()
+
+
+
+        listenerQuota = config.LISTENER_MESSAGE_QUOTA
+        remoteQuota = config.REMOTES_MESSAGE_QUOTA
+        self._receiveFromListener(quota=listenerQuota)
+        self._receiveFromRemotes(quotaPerRemote=remoteQuota)
         return len(self.rxMsgs)
 
     def processReceived(self, limit):

--- a/plenum/config.py
+++ b/plenum/config.py
@@ -150,3 +150,8 @@ log_override_tags = dict(cli={}, demo={})
 
 # TODO needs to be refactored to use a transport protocol abstraction
 UseZStack = True
+
+
+# Number of messages zstack accepts at once
+LISTENER_MESSAGE_QUOTA = 5
+REMOTES_MESSAGE_QUOTA = 5

--- a/plenum/config.py
+++ b/plenum/config.py
@@ -153,5 +153,5 @@ UseZStack = True
 
 
 # Number of messages zstack accepts at once
-LISTENER_MESSAGE_QUOTA = 5
-REMOTES_MESSAGE_QUOTA = 5
+LISTENER_MESSAGE_QUOTA = 100
+REMOTES_MESSAGE_QUOTA = 100

--- a/plenum/test/zstack_tests/test_quotas.py
+++ b/plenum/test/zstack_tests/test_quotas.py
@@ -1,0 +1,55 @@
+import json
+
+from plenum.common.port_dispenser import genHa
+from plenum.common.types import HA
+from plenum.common.util import randomSeed
+from plenum.common.zstack import SimpleZStack
+from plenum.test.zstack_tests.helper import genKeys, SMotor
+from raet.raeting import AutoMode
+
+
+def makeHandler(receivedMessages):
+    def handler(m):
+        msg, sender = m
+        receivedMessages.append(msg)
+        print("Got message", msg)
+
+    return handler
+
+
+def createStack(tdir, name, onlyListener, handler = lambda _: None):
+    params = {
+        "name": name,
+        "ha": HA("0.0.0.0", genHa()[1]),
+        "auto": AutoMode.always,
+        "basedirpath": tdir
+    }
+    return SimpleZStack(params, handler, onlyListener=onlyListener)
+
+
+def testMessageQuota(tdir, looper):
+
+    names = ['Alpha', 'Beta']
+    genKeys(tdir, names)
+
+    alpha = createStack(tdir, names[0], onlyListener=False)
+
+    receivedMessages = []
+    bHandler = makeHandler(receivedMessages)
+    beta = createStack(tdir, names[1], onlyListener=True, handler=bHandler)
+
+    for stack in [alpha, beta]:
+        looper.add(SMotor(stack))
+
+    alpha.connect(beta.name, beta.ha, beta.verKey, beta.publicKey)
+    looper.runFor(0.25)
+
+    messages = []
+    numMessages = 100 * beta.listenerQuota
+    for i in range(numMessages):
+        msg = json.dumps({'random': randomSeed().decode()}).encode()
+        messages.append(json.loads(msg.decode()))
+        alpha.send(msg, beta.name)
+
+    looper.runFor(1)
+    assert messages == receivedMessages


### PR DESCRIPTION
There was a TODO
```
 # TODO: If a stack is being bombarded with messages this can lead to the
 # stack always busy in receiving messages and never getting time to
 # complete processing fo messages.
```
This pull request brings changes that fix it