### PR TITLE
Fix argument order in calling of fix_init_pool_ledger in test_network_setup.py

### DIFF
--- a/plenum/common/test_network_setup.py
+++ b/plenum/common/test_network_setup.py
@@ -61,8 +61,7 @@ class TestNetworkSetup:
 
         baseDir = cls.setup_base_dir(config)
 
-        poolLedger = cls.init_pool_ledger(appendToLedgers, baseDir, config,
-                                          domainTxnFieldOrder)
+        poolLedger = cls.init_pool_ledger(appendToLedgers, baseDir, config, envName)
 
         domainLedger = cls.init_domain_ledger(appendToLedgers, baseDir, config,
                                               envName, domainTxnFieldOrder)


### PR DESCRIPTION
Fix argument order in calling of fix_init_pool_ledger in test_network_setup.py - pass envname instead of fields dict