### PR TITLE
Check client input for the NODE txn

### DIFF
--- a/plenum/common/script_helper.py
+++ b/plenum/common/script_helper.py
@@ -14,7 +14,7 @@ from plenum.common.transactions import PlenumTransactions
 from plenum.common.roles import Roles
 from plenum.common.signer_simple import SimpleSigner
 from plenum.common.constants import TXN_TYPE, TARGET_NYM, DATA, NODE_IP, \
-    NODE_PORT, CLIENT_IP, CLIENT_PORT, ALIAS, NODE, CLIENT_STACK_SUFFIX
+    NODE_PORT, CLIENT_IP, CLIENT_PORT, ALIAS, NODE, CLIENT_STACK_SUFFIX, SERVICES, VALIDATOR
 from plenum.test import waits
 from plenum.test.test_node import getAllReplicas
 
@@ -228,7 +228,8 @@ def submitNodeIpChange(client, stewardWallet, name: str, nym: str,
             NODE_PORT: int(nodePort),
             CLIENT_IP: clientIp,
             CLIENT_PORT: int(clientPort),
-            ALIAS: name
+            ALIAS: name,
+            SERVICES: [VALIDATOR],
         }
     }
     signedOp = stewardWallet.signOp(txn, stewardWallet.defaultId)

--- a/plenum/test/helper.py
+++ b/plenum/test/helper.py
@@ -439,7 +439,7 @@ def checkReqNackWithReason(client, reason: str, sender: str):
                 and sdr == sender:
             found = True
             break
-    assert found
+    assert found, "there is no NAck with reason: {}".format(reason)
 
 
 def waitReqNackWithReason(looper, client, reason: str, sender: str):
@@ -449,6 +449,12 @@ def waitReqNackWithReason(looper, client, reason: str, sender: str):
                                  reason,
                                  sender,
                                  timeout=timeout))
+
+
+def waitReqNackFromPoolWithReason(looper, nodes, client, reason):
+    for node in nodes:
+        waitReqNackWithReason(looper, client, reason,
+                              node.clientstack.name)
 
 
 def checkViewNoForNodes(nodes: Iterable[TestNode], expectedViewNo: int = None):

--- a/plenum/test/pool_transactions/conftest.py
+++ b/plenum/test/pool_transactions/conftest.py
@@ -6,7 +6,7 @@ from plenum.test.test_node import checkNodesConnected
 from plenum.test.node_catchup.helper import \
     ensureClientConnectedToNodesAndPoolLedgerSame
 from plenum.test.pool_transactions.helper import addNewStewardAndNode, \
-    buildPoolClientAndWallet
+    buildPoolClientAndWallet, addNewSteward
 
 
 @pytest.yield_fixture(scope="module")
@@ -85,3 +85,12 @@ def client1Connected(looper, client1):
     looper.add(client1)
     looper.run(client1.ensureConnectedToNodes())
     return client1
+
+
+@pytest.fixture(scope="function")
+def newAdHocSteward(looper, tdir, steward1, stewardWallet):
+    newStewardName = "testClientSteward" + randomString(3)
+    newSteward, newStewardWallet = addNewSteward(looper, tdir, steward1,
+                                                 stewardWallet,
+                                                 newStewardName)
+    return newSteward, newStewardWallet

--- a/plenum/test/pool_transactions/helper.py
+++ b/plenum/test/pool_transactions/helper.py
@@ -45,7 +45,8 @@ def addNewClient(role, looper, creatorClient: Client, creatorWallet: Wallet,
     return wallet
 
 
-def sendAddNewNode(newNodeName, stewardClient, stewardWallet):
+def sendAddNewNode(newNodeName, stewardClient, stewardWallet,
+                   transformOpFunc=None):
     sigseed = randomString(32).encode()
     nodeSigner = SimpleSigner(seed=sigseed)
     (nodeIp, nodePort), (clientIp, clientPort) = genHa(2)
@@ -62,10 +63,15 @@ def sendAddNewNode(newNodeName, stewardClient, stewardWallet):
             SERVICES: [VALIDATOR, ]
         }
     }
+    if transformOpFunc is not None:
+        transformOpFunc(op)
 
     req = stewardWallet.signOp(op)
     stewardClient.submitReqs(req)
-    return req, nodeIp, nodePort, clientIp, clientPort, sigseed
+    return req, \
+           op[DATA].get(NODE_IP), op[DATA].get(NODE_PORT), \
+           op[DATA].get(CLIENT_IP), op[DATA].get(CLIENT_PORT), \
+           sigseed
 
 
 def addNewNode(looper, stewardClient, stewardWallet, newNodeName, tdir, tconf,
@@ -124,7 +130,8 @@ def sendChangeNodeHa(stewardClient, stewardWallet, node, nodeHa, clientHa):
             NODE_PORT: nodePort,
             CLIENT_IP: clientIp,
             CLIENT_PORT: clientPort,
-            ALIAS: node.name
+            ALIAS: node.name,
+            SERVICES: [VALIDATOR]
         }
     }
 

--- a/plenum/test/pool_transactions/test_nodes_with_pool_txns.py
+++ b/plenum/test/pool_transactions/test_nodes_with_pool_txns.py
@@ -1,12 +1,9 @@
+import itertools
 from copy import copy
 
 import base58
 import pytest
-import time
 
-from stp_zmq.zstack import KITZStack
-
-from plenum.common import util
 from plenum.common.keygen_utils import initNodeKeysForBothStacks
 from stp_core.network.port_dispenser import genHa
 from stp_core.types import HA
@@ -18,12 +15,12 @@ from plenum.common.constants import *
 from plenum.common.util import getMaxFailures, randomString
 from plenum.test import waits
 from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies, \
-    checkReqNackWithReason, waitReqNackWithReason, waitForSufficientRepliesForRequests
+    waitReqNackFromPoolWithReason
 from plenum.test.node_catchup.helper import waitNodeLedgersEquality, \
     ensureClientConnectedToNodesAndPoolLedgerSame
-from plenum.test.pool_transactions.helper import addNewClient, addNewNode, \
-    changeNodeHa, addNewStewardAndNode, changeNodeKeys, sendChangeNodeHa, sendAddNewNode, \
-    changeNodeHaAndReconnect, addNewSteward
+from plenum.test.pool_transactions.helper import addNewClient, \
+    addNewStewardAndNode, changeNodeKeys, sendChangeNodeHa, sendAddNewNode, \
+    changeNodeHaAndReconnect
 from plenum.test.test_node import TestNode, checkNodesConnected, \
     checkProtocolInstanceSetup
 
@@ -67,7 +64,7 @@ def testAddNewClient(looper, txnPoolNodeSet, steward1, stewardWallet):
 
 def testStewardCannotAddNodeWithNonBase58VerKey(looper, tdir,
                                                 txnPoolNodeSet,
-                                                steward1, stewardWallet):
+                                                newAdHocSteward):
     """
     Case (https://evernym.atlassian.net/browse/SOV-988):
         Steward accidentally sends the NODE txn with a non base58 verkey.
@@ -75,13 +72,9 @@ def testStewardCannotAddNodeWithNonBase58VerKey(looper, tdir,
         Steward gets NAck response from the pool.
     """
     # create a new steward
-    newStewardName = "testClientSteward" + randomString(3)
-    newSteward, newStewardWallet = addNewSteward(looper, tdir, steward1,
-                                                 stewardWallet,
-                                                 newStewardName)
+    newSteward, newStewardWallet = newAdHocSteward
 
     newNodeName = "Epsilon"
-    (nodeIp, nodePort), (clientIp, clientPort) = genHa(2)
 
     # get hex VerKey
     sigseed = randomString(32).encode()
@@ -89,26 +82,81 @@ def testStewardCannotAddNodeWithNonBase58VerKey(looper, tdir,
     b = base58.b58decode(nodeSigner.identifier)
     hexVerKey = bytearray(b).hex()
 
-    op = {
-        TXN_TYPE: NODE,
-        TARGET_NYM: hexVerKey,
-        DATA: {
-            NODE_IP: nodeIp,
-            NODE_PORT: nodePort,
-            CLIENT_IP: clientIp,
-            CLIENT_PORT: clientPort,
-            ALIAS: newNodeName,
-            SERVICES: [VALIDATOR, ]
-        }
-    }
+    def _setHexVerkey(op):
+        op[TARGET_NYM] = hexVerKey
+        return op
 
-    req = newStewardWallet.signOp(op)
-    newSteward.submitReqs(req)
+    sendAddNewNode(newNodeName, newSteward, newStewardWallet,
+                   transformOpFunc=_setHexVerkey)
+    waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, newSteward,
+                                  'is not a base58 string')
 
-    for node in txnPoolNodeSet:
-        waitReqNackWithReason(looper, newSteward,
-                              'is not a base58 string',
-                              node.clientstack.name)
+
+def testStewardCannotAddNodeWithInvalidHa(looper, tdir,
+                                           txnPoolNodeSet,
+                                           newAdHocSteward):
+    """
+    Case (https://evernym.atlassian.net/browse/SOV-1046):
+        Steward accidentally sends the NODE txn with an invalid HA.
+    The expected result:
+        Steward gets NAck response from the pool.
+    """
+    newNodeName = "Epsilon"
+
+    newSteward, newStewardWallet = newAdHocSteward
+
+    # a sequence of the test cases for each field
+    tests = itertools.chain(
+        itertools.product(
+            (NODE_IP, CLIENT_IP), ('127.0.0.1 ', '256.0.0.1', '0.0.0.0')
+        ),
+        itertools.product(
+            (NODE_PORT, CLIENT_PORT), ('foo', '9700', 0, 65535 + 1, 4351683546843518184)
+        ),
+    )
+
+    for field, value in tests:
+        # create a transform function for each test
+        def _tnf(op): op[DATA].update({field: value})
+        sendAddNewNode(newNodeName, newSteward, newStewardWallet,
+                       transformOpFunc=_tnf)
+        # wait NAcks with exact message. it does not works for just 'is invalid'
+        # because the 'is invalid' will check only first few cases
+        waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, newSteward,
+                                      "'{}' ('{}') is invalid".format(field, value))
+
+
+def testStewardCannotAddNodeWithOutFullFieldsSet(looper, tdir,
+                                 txnPoolNodeSet,
+                                 newAdHocSteward):
+    """
+    Case (https://evernym.atlassian.net/browse/SOV-1064):
+        Steward accidentally sends the NODE txn without full fields set.
+    The expected result:
+        Steward gets NAck response from the pool.
+    """
+    newNodeName = "Epsilon"
+
+    newSteward, newStewardWallet = newAdHocSteward
+
+    # case from the ticket
+    def _renameNodePortField(op):
+        op[DATA].update({NODE_PORT + ' ': op[DATA][NODE_PORT]})
+        del op[DATA][NODE_PORT]
+
+    sendAddNewNode(newNodeName, newSteward, newStewardWallet,
+                   transformOpFunc=_renameNodePortField)
+    waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, newSteward,
+                                  "field '{}' is missed".format(NODE_PORT))
+
+    for fn in (NODE_IP, CLIENT_IP, NODE_PORT, CLIENT_PORT, SERVICES):
+        def _tnf(op): del op[DATA][fn]
+        sendAddNewNode(newNodeName, newSteward, newStewardWallet,
+                       transformOpFunc=_tnf)
+        # wait NAcks with exact message. it does not works for just 'is missed'
+        # because the 'is missed' will check only first few cases
+        waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, newSteward,
+                                      "field '{}' is missed".format(fn))
 
 
 def testStewardCannotAddMoreThanOneNode(looper, txnPoolNodeSet, steward1,
@@ -117,10 +165,8 @@ def testStewardCannotAddMoreThanOneNode(looper, txnPoolNodeSet, steward1,
     newNodeName = "Epsilon"
     sendAddNewNode(newNodeName, steward1, stewardWallet)
 
-    for node in txnPoolNodeSet:
-        waitReqNackWithReason(looper, steward1,
-                              'already has a node with name',
-                              node.clientstack.name)
+    waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, steward1,
+                                  'already has a node with name')
 
 
 def testNonStewardCannotAddNode(looper, txnPoolNodeSet, client1,
@@ -128,10 +174,8 @@ def testNonStewardCannotAddNode(looper, txnPoolNodeSet, client1,
                                 tconf, allPluginsPath):
     newNodeName = "Epsilon"
     sendAddNewNode(newNodeName, client1, wallet1)
-    for node in txnPoolNodeSet:
-        waitReqNackWithReason(looper, client1,
-                              'steward so cannot add a new node',
-                              node.clientstack.name)
+    waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, client1,
+                                  'steward so cannot add a new node')
 
 
 def testClientConnectsToNewNode(looper, txnPoolNodeSet, tdirWithPoolTxns,
@@ -206,10 +250,8 @@ def testNodePortCannotBeChangedByAnotherSteward(looper, txnPoolNodeSet,
     sendChangeNodeHa(steward1, stewardWallet, newNode,
                      nodeHa=nodeNewHa, clientHa=clientNewHa)
 
-    for node in txnPoolNodeSet:
-        waitReqNackWithReason(looper, steward1,
-                              'is not a steward of node',
-                              node.clientstack.name)
+    waitReqNackFromPoolWithReason(looper, txnPoolNodeSet, steward1,
+                                  'is not a steward of node')
 
 
 def testNodePortChanged(looper, txnPoolNodeSet, tdirWithPoolTxns,


### PR DESCRIPTION
Check client input for the NODE txn

- the Node txn must contain (NODE_IP, CLIENT_IP, NODE_PORT, CLIENT_PORT, SERVICES)
- fields NODE_IP, CLIENT_IP are IP addresses
- fields NODE_PORT, CLIENT_PORT are integers (0, 65535]

https://evernym.atlassian.net/browse/SOV-1046
https://evernym.atlassian.net/browse/SOV-1064
https://evernym.atlassian.net/browse/SOV-1062