### PR TITLE
INDY-73: Updated tests enablement statuses

### DIFF
--- a/plenum/test/input_validation/test_common_checks.py
+++ b/plenum/test/input_validation/test_common_checks.py
@@ -6,22 +6,22 @@ from plenum.test.input_validation.messages import messages, messages_names_short
 # TODO: check error messages
 
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_valid(descriptor):
     for m in descriptor.positive_test_cases_valid_message:
         assert descriptor.klass(**m), 'Correct msg passes: {}'.format(m)
 
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_missed_optional_field_pass(descriptor):
     for m in descriptor.positive_test_cases_missed_optional_field:
         assert descriptor.klass(**m), 'Correct msg passes: {}'.format(m)
 
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_invalid_value_fail(descriptor):
     for m in descriptor.negative_test_cases_invalid_value:
         with pytest.raises(TypeError, message='did not raise {}'.format(m)) as exc_info:
@@ -29,8 +29,8 @@ def test_message_invalid_value_fail(descriptor):
         assert exc_info.match(r'validation error: .*')
             
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_missed_required_field_fail(descriptor):
     for m in descriptor.negative_test_cases_missed_required_field:
         with pytest.raises(TypeError, message='did not raise {}'.format(m)) as exc_info:
@@ -38,8 +38,8 @@ def test_message_missed_required_field_fail(descriptor):
         assert exc_info.match(r'validation error: missed fields .*')
 
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_extra_field_fail(descriptor):
     for m in descriptor.negative_test_cases_extra_field:
         with pytest.raises(TypeError, message='did not raise {}'.format(m)) as exc_info:
@@ -47,8 +47,8 @@ def test_message_extra_field_fail(descriptor):
         assert exc_info.match(r'validation error: unknown field .*')
 
 
-@pytest.mark.skip('roll away new validation logic')
-@pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
+@pytest.mark.skip('INDY-78. Roll away new validation logic')
+# @pytest.mark.parametrize('descriptor', argvalues=messages, ids=messages_names_shortcut)
 def test_message_wrong_type_fail(descriptor):
     for m in descriptor.negative_test_cases_wrong_type:
         with pytest.raises(TypeError, message='did not raise {}'.format(m)) as exc_info:

--- a/plenum/test/input_validation/test_handle_one_node_message.py
+++ b/plenum/test/input_validation/test_handle_one_node_message.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.skip('Implement')
+@pytest.mark.skip('INDY-79. Implement')
 def test_empty_args_fail(testNode):
     before_msg = len(testNode.nodeInBox)
     while pytest.raises(AssertionError):
@@ -10,7 +10,7 @@ def test_empty_args_fail(testNode):
         'nodeInBox has not got a message'
 
 
-@pytest.mark.skip('Implement')
+@pytest.mark.skip('INDY-79. Implement')
 def test_too_many_args_fail(testNode):
     before_msg = len(testNode.nodeInBox)
     testNode.handleOneNodeMsg(({}, 'otherNone', 'extra_arg'))

--- a/plenum/test/instances/test_multiple_instance_change_msgs.py
+++ b/plenum/test/instances/test_multiple_instance_change_msgs.py
@@ -13,7 +13,7 @@ from plenum.test import waits
 nodeCount = 7
 
 
-@pytest.mark.skip(reason="Not yet implemented")
+@pytest.mark.skip(reason="INDY-80. Not yet implemented")
 def testMultipleInstanceChangeMsgsMarkNodeAsSuspicious(looper, nodeSet, up):
     maliciousNode = nodeSet.Alpha
     for i in range(0, 5):

--- a/plenum/test/script/test_change_non_primary_node_ha.py
+++ b/plenum/test/script/test_change_non_primary_node_ha.py
@@ -13,7 +13,7 @@ whitelist = ['found legacy entry', "doesn't match", 'reconciling nodeReg',
              'got error while verifying message']
 
 
-@pytest.mark.skip(reason='SOV-330')
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-330')
 def testChangeNodeHaForNonPrimary(looper, txnPoolNodeSet, tdirWithPoolTxns,
                                   poolTxnData, poolTxnStewardNames, tconf):
 

--- a/plenum/test/script/test_change_primary_node_ha.py
+++ b/plenum/test/script/test_change_primary_node_ha.py
@@ -13,7 +13,7 @@ whitelist = ['found legacy entry', "doesn't match", 'reconciling nodeReg',
              'got error while verifying message']
 
 
-@pytest.mark.skip(reason='SOV-330')
+@pytest.mark.skipif('sys.platform == "win32"', reason='SOV-330')
 def testChangeNodeHaForPrimary(looper, txnPoolNodeSet, tdirWithPoolTxns,
                                poolTxnData, poolTxnStewardNames, tconf):
     changeNodeHa(looper,

--- a/plenum/test/test_node_connection.py
+++ b/plenum/test/test_node_connection.py
@@ -48,7 +48,7 @@ def tdirAndLooper(nodeReg):
             yield td, looper
 
 
-@pytest.mark.skip()
+@pytest.mark.skip(reason='INDY-75')
 def testNodesConnectsWhenOneNodeIsLate(allPluginsPath, tdirAndLooper,
                                        nodeReg):
     tdir, looper = tdirAndLooper

--- a/plenum/test/test_node_request.py
+++ b/plenum/test/test_node_request.py
@@ -166,8 +166,8 @@ async def checkIfPropagateRecvdFromNode(recvrNode: TestNode,
 
 
 # noinspection PyIncorrectDocstring
-@pytest.mark.skip(reason="ZStack does not have any mechanism to have stats "
-                         "either remove this once raet is removed "
+@pytest.mark.skip(reason="INDY-76. ZStack does not have any mechanism to have "
+                         "stats either remove this once raet is removed "
                          "or implement a `stats` feature in ZStack")
 def testMultipleRequests(tdir_for_func):
     """

--- a/plenum/test/view_change/test_queueing_req_from_future_view.py
+++ b/plenum/test/view_change/test_queueing_req_from_future_view.py
@@ -20,7 +20,7 @@ logger = getlogger()
 
 # TODO: This test needs to be implemented
 # noinspection PyIncorrectDocstring
-@pytest.mark.skip()
+@pytest.mark.skip(reason='INDY-84. Complete implementation')
 def testQueueingReqFromFutureView(delayed_perf_chk, looper, nodeSet, up,
                                   wallet1, client1):
     """


### PR DESCRIPTION
- Provided all the disabled tests with the ticket references.
- Enabled the tests testChangeNodeHaForPrimary and testChangeNodeHaForNonPrimary on non-Windows platforms.
- Commented out parametrizers at the disabled tests in plenum.test.input_validation.test_common_checks module.