### PR TITLE
Make random string generation efficient

### DIFF
--- a/plenum/test/common/test_random_string.py
+++ b/plenum/test/common/test_random_string.py
@@ -1,0 +1,26 @@
+from plenum.common.util import randomString
+
+# Checks if the function randomString() is returning correct
+# length random string for various lengths
+def test_random_string1():
+    assert (len(randomString(3)) == 3), \
+        "Function randomString(3) did not return string of len 3 characters"
+    assert (len(randomString(20)) == 20), \
+        "Function randomString() did not return string of default len 20 characters"
+    assert (len(randomString(32)) == 32), \
+        "Function call randomString(32) did not return string of len 32 characters"
+    assert (len(randomString(128)) == 128), \
+        "Function randomString(128) did not return string of len 128 characters"
+
+
+# Checks if there is a collision of the returned random strings
+# If we generate a random string with fewer number of characters collision will happen sooner
+# Testing several times has shown numbers less than 5 will cause collision 100%
+# times if tested for about 1000 iterations
+def test_random_string2():
+    test_iterations = 1000
+    rss = []
+    for i in range(test_iterations):
+        rs = randomString(10)
+        assert rs not in rss, "random string # %d exists in list, we have a collision" % i
+        rss.append(rs)


### PR DESCRIPTION
The current algorithm requires calling the libsodium random function 'size' times where size is the expected length of random string
Changed this so that this will require at the most 'abs(size/64)' number of calls
Also we do not need the chars list now we always use only alphabets and digits available in hex this makes it very easy and still gives us what we need