### PR TITLE
Election bug fix

### DIFF
--- a/plenum/server/primary_elector.py
+++ b/plenum/server/primary_elector.py
@@ -360,62 +360,7 @@ class PrimaryElector(PrimaryDecider):
             self.primaryDeclarations[instId][sndrRep] = (prim.name,
                                                          prim.ordSeqNo)
 
-            # If got more than 2f+1 primary declarations then in a position to
-            # decide whether it is the primary or not `2f + 1` declarations
-            # are enough because even when all the `f` malicious nodes declare
-            # a primary, we still have f+1 primary declarations from
-            # non-malicious nodes. One more assumption is that all the non
-            # malicious nodes vote for the the same primary
-
-            # Find for which node there are maximum primary declarations.
-            # Cant be a tie among 2 nodes since all the non malicious nodes
-            # which would be greater than or equal to f+1 would vote for the
-            # same node
-
-            if replica.isPrimary is not None:
-                logger.debug(
-                    "{} Primary already selected; ignoring PRIMARY msg".format(
-                        replica))
-                return
-
-            if self.hasPrimaryQuorum(instId):
-                if replica.isPrimary is None:
-                    primary, seqNo = mostCommonElement(
-                        self.primaryDeclarations[instId].values())
-                    logger.display("{} selected primary {} for instance {} "
-                                   "(view {})".format(replica, primary,
-                                                      instId, self.viewNo),
-                                   extra={"cli": "ANNOUNCE",
-                                          "tags": ["node-election"]})
-                    logger.debug("{} selected primary on the basis of {}".
-                                 format(replica,
-                                        self.primaryDeclarations[instId]),
-                                 extra={"cli": False})
-
-                    # If the maximum primary declarations are for this node
-                    # then make it primary
-                    replica.primaryChanged(primary, seqNo)
-
-                    if instId == 0:
-                        self.previous_master_primary = None
-
-                    # If this replica has nominated itself and since the
-                    # election is over, reset the flag
-                    if self.replicaNominatedForItself == instId:
-                        self.replicaNominatedForItself = None
-
-                    self.node.primary_found()
-
-                    self.scheduleElection()
-                else:
-                    self.discard(prim,
-                                 "it already decided primary which is {}".
-                                 format(replica.primaryName),
-                                 logger.debug)
-            else:
-                logger.debug(
-                    "{} received {} but does it not have primary quorum "
-                    "yet".format(self.name, prim))
+            self.select_primary(instId, prim)
         else:
             self.discard(prim,
                          "already got primary declaration from {}".
@@ -428,6 +373,66 @@ class PrimaryElector(PrimaryDecider):
             # if self.duplicateMsgs[key] > 1:
             #     self.send(BlacklistMsg(
             #         Suspicions.DUPLICATE_PRI_SENT.code, sender))
+
+    def select_primary(self, inst_id: int, prim: Primary):
+        # If got more than 2f+1 primary declarations then in a position to
+        # decide whether it is the primary or not `2f + 1` declarations
+        # are enough because even when all the `f` malicious nodes declare
+        # a primary, we still have f+1 primary declarations from
+        # non-malicious nodes. One more assumption is that all the non
+        # malicious nodes vote for the the same primary
+
+        # Find for which node there are maximum primary declarations.
+        # Cant be a tie among 2 nodes since all the non malicious nodes
+        # which would be greater than or equal to f+1 would vote for the
+        # same node
+
+        replica = self.replicas[inst_id]
+
+        if replica.isPrimary is not None:
+            logger.debug(
+                "{} Primary already selected; ignoring PRIMARY msg".format(
+                    replica))
+            return
+
+        if self.hasPrimaryQuorum(inst_id):
+            if replica.isPrimary is None:
+                primary, seqNo = mostCommonElement(
+                    self.primaryDeclarations[inst_id].values())
+                logger.display("{} selected primary {} for instance {} "
+                               "(view {})".format(replica, primary,
+                                                  inst_id, self.viewNo),
+                               extra={"cli": "ANNOUNCE",
+                                      "tags": ["node-election"]})
+                logger.debug("{} selected primary on the basis of {}".
+                             format(replica,
+                                    self.primaryDeclarations[inst_id]),
+                             extra={"cli": False})
+
+                # If the maximum primary declarations are for this node
+                # then make it primary
+                replica.primaryChanged(primary, seqNo)
+
+                if inst_id == 0:
+                    self.previous_master_primary = None
+
+                # If this replica has nominated itself and since the
+                # election is over, reset the flag
+                if self.replicaNominatedForItself == inst_id:
+                    self.replicaNominatedForItself = None
+
+                self.node.primary_found()
+
+                self.scheduleElection()
+            else:
+                self.discard(prim,
+                             "it already decided primary which is {}".
+                             format(replica.primaryName),
+                             logger.debug)
+        else:
+            logger.debug(
+                "{} received {} but does it not have primary quorum "
+                "yet".format(self.name, prim))
 
     def processReelection(self, reelection: Reelection, sender: str):
         """
@@ -660,8 +665,10 @@ class PrimaryElector(PrimaryDecider):
         logger.debug("{} declaring primary as: {} on the basis of {}".
                      format(replica, primaryName,
                             self.nominations[instId]))
-        self.send(Primary(primaryName, instId, self.viewNo,
-                          lastOrderedSeqNo))
+        prim = Primary(primaryName, instId, self.viewNo,
+                          lastOrderedSeqNo)
+        self.send(prim)
+        self.select_primary(instId, prim)
 
     def sendReelection(self, instId: int,
                        primaryCandidates: Sequence[str] = None) -> None:

--- a/plenum/test/primary_election/test_primary_election_case6.py
+++ b/plenum/test/primary_election/test_primary_election_case6.py
@@ -1,0 +1,53 @@
+import pytest
+
+from plenum.common.types import Primary, Nomination, Reelection
+from plenum.test.delayers import delay
+from plenum.test.test_node import checkNodesConnected, \
+    checkProtocolInstanceSetup
+from stp_core.loop.eventually import eventually
+
+
+@pytest.fixture()
+def case_6_setup(startedNodes):
+    A, B, C, D = startedNodes.nodes.values()
+
+    # A will get Nomination, Primary, Reelection from after elections get over
+    for m in (Nomination, Primary, Reelection):
+        delay(m, frm=B, to=A, howlong=120)
+
+    # A will get Primary earlier than Nominates
+    delay(Nomination, frm=(C, D), to=A, howlong=5)
+
+
+# noinspection PyIncorrectDocstring
+def test_primary_election_case6(case_6_setup, looper, keySharedNodes):
+    """
+    A is disconnected with B so A does not get any Nomination/Primary from
+    B (simulated by a large delay). A gets Nominations delayed due to which is
+    sends Primary only after it has received Primary from other 2 nodes.
+    A should still be able to select a primary and the pool should function.
+    """
+    nodeSet = keySharedNodes
+    A, B, C, D = nodeSet.nodes.values()
+    looper.run(checkNodesConnected(nodeSet))
+
+    inst_ids = (0, 1)
+
+    def chk():
+        # Check that each Primary is received by A before A has sent any Primary
+        primary_recv_times = {
+            i: [entry.starttime for entry in A.elector.spylog.getAll(
+                A.elector.processPrimary) if entry.params['prim'].instId == i]
+            for i in inst_ids
+        }
+        primary_send_times = {
+            i: [entry.starttime for entry in A.elector.spylog.getAll(
+                A.elector.sendPrimary) if entry.params['instId'] == 0]
+            for i in inst_ids
+        }
+
+        for i in inst_ids:
+            assert primary_send_times[i] > primary_recv_times[i]
+
+    looper.run(eventually(chk, retryWait=1, timeout=10))
+    checkProtocolInstanceSetup(looper=looper, nodes=nodeSet, retryWait=1)

--- a/plenum/test/primary_election/test_primary_election_case6.py
+++ b/plenum/test/primary_election/test_primary_election_case6.py
@@ -2,12 +2,13 @@ import pytest
 
 from plenum.common.types import Primary, Nomination, Reelection
 from plenum.test.delayers import delay
+from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
 from plenum.test.test_node import checkNodesConnected, \
     checkProtocolInstanceSetup
 from stp_core.loop.eventually import eventually
 
 
-@pytest.fixture()
+@pytest.fixture(scope='module')
 def case_6_setup(startedNodes):
     A, B, C, D = startedNodes.nodes.values()
 
@@ -16,17 +17,13 @@ def case_6_setup(startedNodes):
         delay(m, frm=B, to=A, howlong=120)
 
     # A will get Primary earlier than Nominates
-    delay(Nomination, frm=(C, D), to=A, howlong=5)
+    delay(Nomination, frm=(C, D), to=A, howlong=10)
 
 
 # noinspection PyIncorrectDocstring
-def test_primary_election_case6(case_6_setup, looper, keySharedNodes):
-    """
-    A is disconnected with B so A does not get any Nomination/Primary from
-    B (simulated by a large delay). A gets Nominations delayed due to which is
-    sends Primary only after it has received Primary from other 2 nodes.
-    A should still be able to select a primary and the pool should function.
-    """
+@pytest.fixture(scope='module')
+def elections_done(case_6_setup, looper, keySharedNodes):
+    # Make sure elections are done successfully
     nodeSet = keySharedNodes
     A, B, C, D = nodeSet.nodes.values()
     looper.run(checkNodesConnected(nodeSet))
@@ -47,7 +44,21 @@ def test_primary_election_case6(case_6_setup, looper, keySharedNodes):
         }
 
         for i in inst_ids:
-            assert primary_send_times[i] > primary_recv_times[i]
+            assert primary_send_times[i][0] > max(primary_recv_times[i])
 
-    looper.run(eventually(chk, retryWait=1, timeout=10))
+    looper.run(eventually(chk, retryWait=1, timeout=15))
     checkProtocolInstanceSetup(looper=looper, nodes=nodeSet, retryWait=1)
+    
+    for i in inst_ids:
+        assert B.replicas[i].name not in A.elector.nominations[i]
+        assert B.replicas[i].name not in A.elector.primaryDeclarations[i]
+
+
+def test_primary_election_case6(elections_done, looper, client1, wallet1):
+    """
+    A is disconnected with B so A does not get any Nomination/Primary from
+    B (simulated by a large delay). A gets Nominations delayed due to which is
+    sends Primary only after it has received Primary from other 2 nodes.
+    A should still be able to select a primary and the pool should function.
+    """
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet1, client1, 5)

--- a/plenum/test/test_node.py
+++ b/plenum/test/test_node.py
@@ -269,7 +269,9 @@ class TestNode(TestNodeCore, Node):
 
 
 @spyable(methods=[
-        PrimaryElector.discard
+        PrimaryElector.discard,
+        PrimaryElector.processPrimary,
+        PrimaryElector.sendPrimary
     ])
 class TestPrimaryElector(PrimaryElector):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
if `f` nodes do not send Primary and the node is the last one to send Primary, then it was not able to decide the primary, since a node was doing "primary setting" only on receiving a Primary message, changed that to try "setting primary" after sending Primary too