### PR TITLE
Commented out raet logging

### DIFF
--- a/plenum/cli/cli.py
+++ b/plenum/cli/cli.py
@@ -258,7 +258,9 @@ class Cli:
 
         if logFileName:
             Logger().enableFileLogging(logFileName)
-        Logger().setupRaet(RAETVerbosity, RAETLogFile)
+
+        # TODO: If we want RAET logging in CLI we need fix this. See INDY-315.
+        #Logger().setupRaet(RAETVerbosity, RAETLogFile)
 
         self.logger = getlogger("cli")
         self.print("\n{}-CLI (c) 2017 Evernym, Inc.".format(self.properName))


### PR DESCRIPTION
This line causes the CLI tests to fail because it it is closing and reiniting the stdout file descriptor, which is killing pytest's ability to capture output.

Commenting this line resolves the test failures.

INDY-315